### PR TITLE
Add ability to control what http method to handle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ REQUESTLOGS = {
     'SERIALIZER_CLASS': 'requestlogs.storages.BaseEntrySerializer',
     'SECRETS': ['password', 'token'],
     'ATTRIBUTE_NAME': '_requestlog',
+    'METHODS': ('GET', 'PUT', 'PATCH', 'POST', 'DELETE'),
 }
 ```
 
@@ -120,6 +121,8 @@ REQUESTLOGS = {
   - List of keys in request/response data which will be replaced with `'***'` in the stored entry.
 - **ATTRIBUTE_NAME**
   - django-requestlogs internally attaches the entry object to the Django request object, and uses this attribute name. Override if it causes collisions.
+- **METHODS**
+  - django-requestlogs will handle only HTTP methods defined by this setting. By default it handles all HTTP methods.
 
 
 # Logging with Request ID

--- a/requestlogs/base.py
+++ b/requestlogs/base.py
@@ -11,6 +11,7 @@ DEFAULT_SETTINGS = {
     'SECRETS': ['password', 'token'],
     'REQUEST_ID_ATTRIBUTE_NAME': 'request_id',
     'REQUEST_ID_HTTP_HEADER': None,
+    'METHODS': ('GET', 'PUT', 'PATCH', 'POST', 'DELETE')
 }
 
 

--- a/requestlogs/middleware.py
+++ b/requestlogs/middleware.py
@@ -14,7 +14,11 @@ class RequestLogsMiddleware(object):
 
     def __call__(self, request):
         response = self.get_response(request)
-        get_requestlog_entry(request).finalize(response)
+
+        # handle only methods defined in the settings
+        if request.method.upper() in tuple(m.upper() for m in SETTINGS['METHODS']):
+            get_requestlog_entry(request).finalize(response)
+
         return response
 
 


### PR DESCRIPTION
At some point, it might be useful not to log some HTTP methods. For example, if you want to get a detailed log only of non-safe methods (post, put, patch, delete) and ignore read method (get).