### PR TITLE
[-] Basic django view data logging

### DIFF
--- a/requestlogs/base.py
+++ b/requestlogs/base.py
@@ -8,7 +8,7 @@ DEFAULT_SETTINGS = {
     'ENTRY_CLASS': 'requestlogs.entries.RequestLogEntry',
     'STORAGE_CLASS': 'requestlogs.storages.LoggingStorage',
     'SERIALIZER_CLASS': 'requestlogs.storages.BaseEntrySerializer',
-    'SECRETS': ['password', 'token'],
+    'SECRETS': ['password', 'password1', 'password2', 'token'],
     'REQUEST_ID_ATTRIBUTE_NAME': 'request_id',
     'REQUEST_ID_HTTP_HEADER': None,
     'METHODS': ('GET', 'PUT', 'PATCH', 'POST', 'DELETE')

--- a/requestlogs/entries.py
+++ b/requestlogs/entries.py
@@ -19,7 +19,9 @@ class RequestHandler(object):
 
     @property
     def data(self):
-        return None
+        if self.request.method not in ['POST', 'PUT', 'PATCH']:
+            return None
+        return getattr(self.request, self.method, None)
 
     @property
     def query_params(self):

--- a/requestlogs/entries.py
+++ b/requestlogs/entries.py
@@ -19,9 +19,7 @@ class RequestHandler(object):
 
     @property
     def data(self):
-        if self.request.method not in ['POST', 'PUT', 'PATCH']:
-            return None
-        return getattr(self.request, self.method, None)
+        return remove_secrets(self.request.POST)
 
     @property
     def query_params(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -109,10 +109,6 @@ def api_view_function(request):
     return Response({'status': 'ok'})
 
 
-def django_view(request):
-    return HttpResponse('Nothing')
-
-
 urlpatterns = [
     url(r'^/?$', View.as_view()),
     url(r'^django/?$', BasicDjangoView.as_view()),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -202,7 +202,7 @@ class TestStoredData(RequestLogsTestMixin, APITestCase):
                 'request': {
                     'method': 'GET',
                     'full_path': '/django',
-                    'data': None,
+                    'data': '{}',
                     'query_params': "{}",
                 },
                 'response': {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,11 +4,13 @@ from unittest.mock import patch, Mock
 
 import django
 from django.contrib.auth import get_user_model
+from django.http import HttpResponse
 from django.test import override_settings, modify_settings
 if django.VERSION[0] < 2:
     from django.conf.urls import url
 else:
     from django.urls import re_path as url
+from django.views import View as DjangoView
 from rest_framework import serializers
 from rest_framework import viewsets
 from rest_framework.authentication import BaseAuthentication
@@ -94,13 +96,26 @@ class ServerErrorView(APIView):
         {'one': 1}['two']
 
 
+class BasicDjangoView(DjangoView):
+    def get(self, request):
+        return HttpResponse('')
+
+    def post(self, request):
+        return HttpResponse('')
+
+
 @api_view(['GET'])
 def api_view_function(request):
     return Response({'status': 'ok'})
 
 
+def django_view(request):
+    return HttpResponse('Nothing')
+
+
 urlpatterns = [
     url(r'^/?$', View.as_view()),
+    url(r'^django/?$', BasicDjangoView.as_view()),
     url(r'^user/?$', ProtectedView.as_view()),
     url(r'^set-user-manually/?$', SetUserManually.as_view()),
     url(r'^login/?$', LoginView.as_view()),
@@ -178,6 +193,43 @@ class TestStoredData(RequestLogsTestMixin, APITestCase):
                 },
                 'user': {'id': None, 'username': None},
             })
+
+    def test_get_django_view(self):
+        with patch('tests.test_views.TestStorage.do_store') as mocked_store:
+            response = self.client.get('/django')
+            self.assert_stored(mocked_store, {
+                'action_name': None,
+                'request': {
+                    'method': 'GET',
+                    'full_path': '/django',
+                    'data': None,
+                    'query_params': "{}",
+                },
+                'response': {
+                    'status_code': 200,
+                    'data': None
+                },
+                'user': {'id': None, 'username': None},
+            })
+
+    def test_post_django_view(self):
+        with patch('tests.test_views.TestStorage.do_store') as mocked_store:
+            response = self.client.post('/django', data={'test': 1})
+            self.assert_stored(mocked_store, {
+                'action_name': None,
+                'request': {
+                    'method': 'POST',
+                    'full_path': '/django',
+                    'data': '{"test": "1"}',
+                    'query_params': "{}",
+                },
+                'response': {
+                    'status_code': 200,
+                    'data': None
+                },
+                'user': {'id': None, 'username': None},
+            })
+
 
     def test_api_view(self):
         with patch('tests.test_views.TestStorage.do_store') as mocked_store:
@@ -394,7 +446,7 @@ class TestServerError(RequestLogsTestMixin, APITestCase):
         with patch('tests.test_views.TestStorage.do_store') as mocked_store:
             self.assertRaises(
                 KeyError, self.client.post, '/error', {'pay': 'load'})
-            self.expected['request']['data'] = None
+            self.expected['request']['data'] = '{"pay": "load"}'
             self.assert_stored(mocked_store, self.expected)
 
 


### PR DESCRIPTION
## What

The code in this change set logs `data` for basic django views for `POST`. As well as adding `password1` and `password2` to the `SECRET` list.

## Why

While browsing the logs using `requestlogs` in the django admin, I noticed that any `data` submitted in the django admin was not logged which would be helpful in debugging.

Also, now that data is being logged from the django admin, `password1` and `password2` that come from the django password reset form were added to the `SECRET` list.

## How

Updates to the ``RequestHandler`` were done in order to return any data submitted. Here is a sample payload from the admin.

```{
  'action_name': None,
  'execution_time': '00:00:00.000403',
  'timestamp': '2020-12-31T17:46:56.141626Z',
  'ip_address': None,
  'request': OrderedDict([
    ('method', 'POST'),
    ('full_path', '/admin/auth/user/2/password/'),
    ('data', '{"csrfmiddlewaretoken": "ujirKs0o9QZBGNNlj85TelAdhcRrufuy2HuRH12dudLCMH9uO27fuMyJUDtKBMUG", "username": "user@test.com", "password1": "***", "password2": "***"}'),
    ('query_params', '{}'),
    ('request_id', '71a7cd5f5905468392c4371ef1543bf9')
  ]),
  'response': OrderedDict([
    ('status_code', 200),
    ('data', None)
  ]),
  'user': OrderedDict([
    ('id', 1),
    ('username', 'user@test.com')])
  }
```