### PR TITLE
use general primary key identifier

### DIFF
--- a/requestlogs/entries.py
+++ b/requestlogs/entries.py
@@ -108,7 +108,7 @@ class RequestLogEntry(object):
 
         user = self._user or getattr(self.django_request, 'user', None)
         if user and user.is_authenticated:
-            ret['id'] = user.id
+            ret['id'] = user.pk
             ret['username'] = user.username
 
         return ret


### PR DESCRIPTION
Hello,
great package!

In my project the user primary key is not called **id**, so I stumbled across this call.

**pk** is the general call of the primary key, see https://docs.djangoproject.com/en/3.2/topics/db/queries/#the-pk-lookup-shortcut .