### PR TITLE
Using USERNAME_FIELD instead of fixed username

### DIFF
--- a/requestlogs/entries.py
+++ b/requestlogs/entries.py
@@ -111,14 +111,16 @@ class RequestLogEntry(object):
     @property
     def user(self):
         ret = {
-            'id': None,
-            'username': None,
+            'id': None
         }
 
         user = self._user or getattr(self.django_request, 'user', None)
         if user and user.is_authenticated:
             ret['id'] = user.pk
-            ret['username'] = user.username
+            if user.__class__.USERNAME_FIELD:
+                ret[user.__class__.USERNAME_FIELD] = getattr(user, user.__class__.USERNAME_FIELD, None)
+            else:
+                ret['username'] = user.username
 
         return ret
 


### PR DESCRIPTION
Using [_USERNAME_FIELD_](https://docs.djangoproject.com/en/4.0/topics/auth/customizing/#django.contrib.auth.models.CustomUser) field each app can define its own way of working and we don't let the fixed "username" field.

Same problem: 
  * #12 
  * #21 