### PR TITLE
ensure_ascii=False in json.dumps so that characters are displayed as-is

### DIFF
--- a/requestlogs/storages.py
+++ b/requestlogs/storages.py
@@ -18,7 +18,7 @@ class JsonDumpField(serializers.Field):
                 if isinstance(field_value, UploadedFile):
                     value[field_name] = (
                         f'<{field_value.__class__.__name__}, size={field_value.size}>')
-        return json.dumps(value, cls=JSONEncoder)
+        return json.dumps(value, cls=JSONEncoder, ensure_ascii=False)
 
 
 class BaseRequestSerializer(serializers.Serializer):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -35,7 +35,7 @@ class View(APIView):
         return Response(self.get_response_data())
 
     def post(self, request):
-        return Response({'status': 'ok'})
+        return Response({'status': 'ok', 'unicode_test': 'öú 汉'})
 
     def get_response_data(self):
         return {}
@@ -193,7 +193,7 @@ class TestStoredData(RequestLogsTestMixin, APITestCase):
                 },
                 'response': {
                     'status_code': 200,
-                    'data': '{"status": "ok"}',
+                    'data': '{"status": "ok", "unicode_test": "öú 汉"}',
                 },
                 'user': {'id': None, 'username': None},
             })


### PR DESCRIPTION
When added a new unicode value to `test_post_bare_view` test like this: `'unicode_test': 'àéìöú 汉'`

JsonDumpField gives me the following error:

```
        for k, v in expected_data.items():
>           assert stored_data.pop(k) == v
E           assert OrderedDict([... \\u6c49"}')]) == {'data': '{"s...us_code': 200}
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {'data': '{"status": "ok", "unicode_test": "\\u00e0\\u00e9\\u00ec\\u00f6\\u00fa \\u6c49"}'} != {'data': '{"status": "ok", "unicode_test": "àéìöú 汉"}'}
E             Use -v to get more diff
```

To fix this, I added `ensure_ascii=False` property in json.dumps() so that characters are displayed as-is.
