### PR TITLE
Make `ensure_asciiTrue` by default, configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ REQUESTLOGS = {
     'SECRETS': ['password', 'token'],
     'ATTRIBUTE_NAME': '_requestlog',
     'METHODS': ('GET', 'PUT', 'PATCH', 'POST', 'DELETE'),
+    'JSON_ENSURE_ASCII': True,
 }
 ```
 
@@ -125,6 +126,8 @@ REQUESTLOGS = {
   - django-requestlogs internally attaches the entry object to the Django request object, and uses this attribute name. Override if it causes collisions.
 - **METHODS**
   - django-requestlogs will handle only HTTP methods defined by this setting. By default it handles all HTTP methods.
+- **JSON_ENSURE_ASCII**
+  - whether to dump the json data (of request and response) with `ensure_ascii=True/False`. Default is `True`. Use `False` to change it so that characters are displayed as-is.
 
 
 # Logging with Request ID

--- a/requestlogs/base.py
+++ b/requestlogs/base.py
@@ -11,7 +11,8 @@ DEFAULT_SETTINGS = {
     'SECRETS': ['password', 'password1', 'password2', 'token', 'HTTP_AUTHORIZATION'],
     'REQUEST_ID_ATTRIBUTE_NAME': 'request_id',
     'REQUEST_ID_HTTP_HEADER': None,
-    'METHODS': ('GET', 'PUT', 'PATCH', 'POST', 'DELETE')
+    'METHODS': ('GET', 'PUT', 'PATCH', 'POST', 'DELETE'),
+    'JSON_ENSURE_ASCII': True,
 }
 
 

--- a/requestlogs/storages.py
+++ b/requestlogs/storages.py
@@ -18,7 +18,7 @@ class JsonDumpField(serializers.Field):
                 if isinstance(field_value, UploadedFile):
                     value[field_name] = (
                         f'<{field_value.__class__.__name__}, size={field_value.size}>')
-        return json.dumps(value, cls=JSONEncoder, ensure_ascii=False)
+        return json.dumps(value, cls=JSONEncoder, ensure_ascii=SETTINGS['JSON_ENSURE_ASCII'])
 
 
 class BaseRequestSerializer(serializers.Serializer):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -193,6 +193,28 @@ class TestStoredData(RequestLogsTestMixin, APITestCase):
                 },
                 'response': {
                     'status_code': 200,
+                    'data': '{"status": "ok", "unicode_test": "\\u00f6\\u00fa \\u6c49"}',
+                },
+                'user': {'id': None, 'username': None},
+            })
+
+    @override_settings(
+        REQUESTLOGS={'STORAGE_CLASS': 'tests.test_views.TestStorage', 'JSON_ENSURE_ASCII': False},
+    )
+    def test_post_bare_view_ensure_ascii_false(self):
+        with patch('tests.test_views.TestStorage.do_store') as mocked_store:
+            response = self.client.post('/', data={'test': 1})
+            self.assert_stored(mocked_store, {
+                'action_name': 'post-other-stuff',
+                'request': {
+                    'method': 'POST',
+                    'full_path': '/',
+                    'data': '{"test": "1"}',
+                    'query_params': "{}",
+                    'request_headers': '{"HTTP_COOKIE": ""}',
+                },
+                'response': {
+                    'status_code': 200,
                     'data': '{"status": "ok", "unicode_test": "öú 汉"}',
                 },
                 'user': {'id': None, 'username': None},


### PR DESCRIPTION
Use `JSON_ENSURE_ASCII` in settings to control this behaviour.