### PR TITLE
Running tox tests against Python 3.11 & 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
   {py38}-django{3latest,4latest}-drf{3latest}
   {py39}-django{3latest,4latest}-drf{3latest}
   {py310}-django{3latest,4latest}-drf{3latest}
+  {py311}-django{4latest}-drf{3latest}
+  {py312}-django{4latest}-drf{3latest}
 
 [gh-actions]
 python =
@@ -15,6 +17,8 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
+  3.12: py312
 
 [testenv]
 setenv =


### PR DESCRIPTION
Small follow-up to #45, enable testing of Python 3.11 and 3.12 through tox.ini
