### PR TITLE
Support Django 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,7 @@ setup(
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
-    ],  
+        'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 VERSION = '0.7.1'
 
 requirements = (
-    'Django>=1.11,<5.0',
+    'Django>=1.11,<6.0',
     'djangorestframework>=3.0,<4.0',
     'setuptools',
 )
@@ -54,5 +54,6 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ envlist =
   {py37}-django{2latest,3latest}-drf{3latest}
   {py38}-django{3latest,4latest}-drf{3latest}
   {py39}-django{3latest,4latest}-drf{3latest}
-  {py310}-django{3latest,4latest}-drf{3latest}
-  {py311}-django{4latest}-drf{3latest}
-  {py312}-django{4latest}-drf{3latest}
+  {py310}-django{3latest,4latest,5latest}-drf{3latest}
+  {py311}-django{4latest,5latest}-drf{3latest}
+  {py312}-django{4latest,5latest}-drf{3latest}
 
 [gh-actions]
 python =
@@ -35,3 +35,5 @@ deps =
   django2latest: Django>=2.0,<3.0
   django3latest: Django>=3.0,<4.0
   django4latest: Django>=4.0,<5.0
+  django5latest: Django==5.0b1
+  #django5latest: Django>=5.0,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
   {py38}-django{3latest,4latest}-drf{3latest}
   {py39}-django{3latest,4latest}-drf{3latest}
   {py310}-django{3latest,4latest}-drf{3latest}
+  {py311}-django{4latest}-drf{3latest}
+  {py312}-django{4latest}-drf{3latest}
 
 [gh-actions]
 python =
@@ -15,6 +17,8 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
+  3.12: py312
 
 [testenv]
 setenv =


### PR DESCRIPTION
_This builds on #46._

This removes the restriction towards Django 5.0 and declares support for all the Django versions.

For now, I've added a specific version pin in `tox.ini` for the beta 1 release. This can be updated/removed to a more open version specifier when 5.0 final (December 2023) is released.