### PR TITLE
Use the final Django 5 releases

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,4 @@ deps =
   django2latest: Django>=2.0,<3.0
   django3latest: Django>=3.0,<4.0
   django4latest: Django>=4.0,<5.0
-  django5latest: Django==5.0b1
-  #django5latest: Django>=5.0,<6.0
+  django5latest: Django>=5.0,<6.0


### PR DESCRIPTION
This switches from the beta version of Django 5.0 to use Django 5.0 (or 5.0.1 since today).


@Raekkeri any chance that you will cut a new release? I'd rather avoid having to install from a git-commit.